### PR TITLE
fixes ts-misuse and add parseFloat on average

### DIFF
--- a/history.js
+++ b/history.js
@@ -353,7 +353,7 @@ function generateDemo(msg) {
 }
 
 function pushHistory(id, state) {
-    // Push into redis
+    // Push into history
     if (history[id]) {
         var settings = history[id][adapter.namespace];
 
@@ -754,4 +754,3 @@ function getDirectories(path) {
         return fs.statSync(path + '/' + file).isDirectory();
     });
 }
-

--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -70,7 +70,7 @@ function aggregation(options, data) {
             if (options.result[index].val.val === null || options.result[index].val.val > data[i].val) options.result[index].val.val = data[i].val;
         } else if (options.aggregate === 'average') {
             if (!options.result[index].val.ts) options.result[index].val.ts = Math.round(options.start + ((index + 0.5) * options.step));
-            options.result[index].val.val += data[i].val;
+            options.result[index].val.val += parseFloat(data[i].val);
             options.averageCount[index]++;
         } else if (options.aggregate === 'total') {
             if (!options.result[index].val.ts) options.result[index].val.ts = Math.round(options.start + ((index + 0.5) * options.step));
@@ -144,15 +144,15 @@ function finishAggregation(options) {
                     else {
                         options.result.splice(ii + 1, 0, {
                             ts:  options.result[ii].max.ts,
-                            val: options.result[ii].max.ts
+                            val: options.result[ii].max.val
                         });
                         options.result.splice(ii + 2, 0, {
                             ts:  options.result[ii].end.ts,
-                            val: options.result[ii].end.ts
+                            val: options.result[ii].end.val
                         });
                         options.result[ii] = {
                             ts:  options.result[ii].start.ts,
-                            val: options.result[ii].start.ts
+                            val: options.result[ii].start.val
                         };
                     }
                 } else


### PR DESCRIPTION
while looking into the code I realized that there is one place where
„ts“ is assigned as „val“ - in my opinion wrongly.
Additionally i would use a parseFloat also on „average“ method.