### PR TITLE
added argument for catch for Compatibility

### DIFF
--- a/main.js
+++ b/main.js
@@ -1035,7 +1035,7 @@ function getDirectories(path) {
         return fs.readdirSync(path).filter(file => {
             try {
                 return fs.statSync(path + '/' + file).isDirectory()
-            } catch {
+            } catch(e) {
                 //ignore entry
                 return false;
             }


### PR DESCRIPTION
some js/node-js Versions don't seem to support catch without an Argument, so just adding it for compatibility

for example my instance of history now crashes on startup after updating it.