### PR TITLE
honour round option when averaging

### DIFF
--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -410,6 +410,7 @@ function finishAggregation(options) {
         }
         options.result = finalResult;
     } else if (options.aggregate === 'average') {
+        const round = options.round || 100;
         let startIndex = 0;
         let endIndex = options.result.length;
         const finalResult = [];
@@ -425,7 +426,7 @@ function finishAggregation(options) {
             if (options.result[k] !== undefined && options.result[k].val.ts) {
                 finalResult.push({
                     ts:  options.result[k].val.ts,
-                    val: options.result[k].val.val !== null ? Math.round(options.result[k].val.val / options.averageCount[k] * 100) / 100 : null
+                    val: options.result[k].val.val !== null ? Math.round(options.result[k].val.val / options.averageCount[k] * round) / round : null
                 });
             } else {
                 // no one value in this interval


### PR DESCRIPTION
When averaging, the round option is ignored and a fixed 2 decimal rounding is used. 
This change uses the round option with fallback to the original 2 decimal rounding.